### PR TITLE
Replace secrets.token_urlsafe by compatible code

### DIFF
--- a/webscrapbook/util.py
+++ b/webscrapbook/util.py
@@ -10,7 +10,7 @@ import math
 import re
 import hashlib
 import time
-from secrets import token_urlsafe
+import base64
 from urllib.parse import quote, unquote
 
 
@@ -428,10 +428,10 @@ class TokenHandler():
 
         self.check_delete_expire(now)
 
-        token = token_urlsafe()
+        token = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b'=').decode('ascii')
         token_file = os.path.join(self.cache_dir, token)
         while os.path.lexists(token_file):
-            token = token_urlsafe()
+            token = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b'=').decode('ascii')
             token_file = os.path.join(self.cache_dir, token)
 
         os.makedirs(os.path.dirname(token_file), exist_ok=True)


### PR DESCRIPTION
[`secrets.token_urlsafe([nbytes=None])`](https://docs.python.org/3/library/secrets.html#secrets.token_urlsafe)
> Return a random URL-safe text string, containing nbytes random bytes. The text is Base64 encoded, so on average each byte results in approximately 1.3 characters.

In order to make it compatible with python 3.5, this function is replaced with the code which does the exact same [job](https://github.com/python/cpython/blob/534136ac6790a701e24f364a9b7f1e34bf5f3ce7/Lib/secrets.py#L73)