### PR TITLE
Drop cryptography package from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,10 @@ setup(
         'lxml >= 4.0',
         'commonmark >= 0.8',
         ],
+    extras_require={
+        "adhoc_ssl": ["cryptography"],
+        "adhoc_ssl_werkzeug_0_x": ["pyopenssl"],  # that requires cryptography
+        },
     packages=find_packages(),
     package_data={
         'webscrapbook': [

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'flask >= 1.1',
         'werkzeug',
         'jinja2',
-        'cryptography',
         'lxml >= 4.0',
         'commonmark >= 0.8',
         ],

--- a/webscrapbook/resources/config.md
+++ b/webscrapbook/resources/config.md
@@ -321,6 +321,18 @@ purpose or for private usage, e.g.:
 
 and use "domain.key" for ssl_key and "domain.crt" for ssl_cert.
 
+To use ad hoc TLS certificates, `cryptograpy` package should be installed
+directly or as an extra option with
+
+    python -m pip install -U webscrapbook[adhoc_ssl]
+
+Prior to 1.0 version `werkzeug` package required `pyopenssl`
+for the same purpose (that has `cryptography` as transitive
+dependency). If you prefer that particular version, likely you know
+how to satisfy the dependency. Alternatively do
+
+    python -m pip install webscrapbook[adhoc_ssl_werkzeug_0_x]
+
 (default: false)
 
 


### PR DESCRIPTION
It is never imported (at least directly).

I am not completely sure, but at least on Ubuntu-20.04 and python-3.8 TLS works without `cryptography` package.