### PR TITLE
Use zip_tuple_timestamp in more tests

### DIFF
--- a/test/test_app_actions.py
+++ b/test/test_app_actions.py
@@ -468,7 +468,7 @@ class TestView(unittest.TestCase):
                     path='/archive.zip!/',
                     pathparts=['/archive.zip', ''],
                     subentries={
-                        ('index.html', 'file', 19, 536428800),
+                        ('index.html', 'file', 19, zip_tuple_timestamp((1987, 1, 1, 0, 0, 0))),
                         },
                     )
 
@@ -1396,13 +1396,13 @@ class TestList(TestActions):
                     'name': 'index.html',
                     'type': 'file',
                     'size': 19,
-                    'last_modified': 536515200,
+                    'last_modified': zip_tuple_timestamp((1987, 1, 2, 0, 0, 0)),
                     }) in sse)
                 self.assertTrue(('message', {
                     'name': 'subdir',
                     'type': 'dir',
                     'size': None,
-                    'last_modified': 536518800,
+                    'last_modified': zip_tuple_timestamp((1987, 1, 2, 1, 0, 0)),
                     }) in sse)
                 self.assertTrue(('complete', None) in sse)
 
@@ -1418,13 +1418,13 @@ class TestList(TestActions):
                     'name': 'index.html',
                     'type': 'file',
                     'size': 19,
-                    'last_modified': 536515200,
+                    'last_modified': zip_tuple_timestamp((1987, 1, 2, 0, 0, 0)),
                     }) in sse)
                 self.assertTrue(('message', {
                     'name': 'subdir',
                     'type': 'dir',
                     'size': None,
-                    'last_modified': 536518800,
+                    'last_modified': zip_tuple_timestamp((1987, 1, 2, 1, 0, 0)),
                     }) in sse)
                 self.assertTrue(('complete', None) in sse)
 
@@ -1440,7 +1440,7 @@ class TestList(TestActions):
                     'name': 'index.html',
                     'type': 'file',
                     'size': 22,
-                    'last_modified': 536601600,
+                    'last_modified': zip_tuple_timestamp((1987, 1, 3, 0, 0, 0)),
                     }) in sse)
                 self.assertTrue(('message', {
                     'name': 'subdir',
@@ -1462,7 +1462,7 @@ class TestList(TestActions):
                     'name': 'index.html',
                     'type': 'file',
                     'size': 22,
-                    'last_modified': 536601600,
+                    'last_modified': zip_tuple_timestamp((1987, 1, 3, 0, 0, 0)),
                     }) in sse)
                 self.assertTrue(('message', {
                     'name': 'subdir',

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -10,7 +10,7 @@ import time
 import zipfile
 import collections
 from webscrapbook import util
-from webscrapbook.util import frozendict
+from webscrapbook.util import frozendict, zip_tuple_timestamp
 
 root_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -476,22 +476,22 @@ class TestUtils(unittest.TestCase):
 
             self.assertEqual(
                 util.zip_file_info(zip_filename, 'file.txt'),
-                ('file.txt', 'file', 6, 536428800)
+                ('file.txt', 'file', 6, zip_tuple_timestamp((1987, 1, 1, 0, 0, 0)))
                 )
 
             self.assertEqual(
                 util.zip_file_info(zip_filename, 'folder'),
-                ('folder', 'dir', None, 567964800)
+                ('folder', 'dir', None, zip_tuple_timestamp((1988, 1, 1, 0, 0, 0)))
                 )
 
             self.assertEqual(
                 util.zip_file_info(zip_filename, 'folder/'),
-                ('folder', 'dir', None, 567964800)
+                ('folder', 'dir', None, zip_tuple_timestamp((1988, 1, 1, 0, 0, 0)))
                 )
 
             self.assertEqual(
                 util.zip_file_info(zip_filename, 'folder/.gitkeep'),
-                ('.gitkeep', 'file', 3, 599587200)
+                ('.gitkeep', 'file', 3, zip_tuple_timestamp((1989, 1, 1, 0, 0, 0)))
                 )
 
             self.assertEqual(
@@ -516,7 +516,7 @@ class TestUtils(unittest.TestCase):
 
             self.assertEqual(
                 util.zip_file_info(zip_filename, 'implicit_folder/.gitkeep'),
-                ('.gitkeep', 'file', 4, 631123200)
+                ('.gitkeep', 'file', 4, zip_tuple_timestamp((1990, 1, 1, 0, 0, 0)))
                 )
 
             self.assertEqual(
@@ -533,7 +533,7 @@ class TestUtils(unittest.TestCase):
             with zipfile.ZipFile(zip_filename, 'r') as zip:
                 self.assertEqual(
                     util.zip_file_info(zip, 'file.txt'),
-                    ('file.txt', 'file', 6, 536428800)
+                    ('file.txt', 'file', 6, zip_tuple_timestamp((1987, 1, 1, 0, 0, 0)))
                     )
         finally:
             try:
@@ -551,39 +551,39 @@ class TestUtils(unittest.TestCase):
                 zh.writestr(zipfile.ZipInfo('implicit_folder/.gitkeep', (1990, 1, 1, 0, 0, 0)), '1234')
 
             self.assertEqual(set(util.zip_listdir(zip_filename, '')), {
-                ('folder', 'dir', None, 567964800),
+                ('folder', 'dir', None, zip_tuple_timestamp((1988, 1, 1, 0, 0, 0))),
                 ('implicit_folder', 'dir', None, None),
-                ('file.txt', 'file', 6, 536428800),
+                ('file.txt', 'file', 6, zip_tuple_timestamp((1987, 1, 1, 0, 0, 0))),
                 })
 
             self.assertEqual(set(util.zip_listdir(zip_filename, '/')), {
-                ('folder', 'dir', None, 567964800),
+                ('folder', 'dir', None, zip_tuple_timestamp((1988, 1, 1, 0, 0, 0))),
                 ('implicit_folder', 'dir', None, None),
-                ('file.txt', 'file', 6, 536428800),
+                ('file.txt', 'file', 6, zip_tuple_timestamp((1987, 1, 1, 0, 0, 0))),
                 })
 
             self.assertEqual(set(util.zip_listdir(zip_filename, '', recursive=True)), {
-                ('folder', 'dir', None, 567964800),
-                ('folder/.gitkeep', 'file', 3, 599587200),
+                ('folder', 'dir', None, zip_tuple_timestamp((1988, 1, 1, 0, 0, 0))),
+                ('folder/.gitkeep', 'file', 3, zip_tuple_timestamp((1989, 1, 1, 0, 0, 0))),
                 ('implicit_folder', 'dir', None, None),
-                ('implicit_folder/.gitkeep', 'file', 4, 631123200),
-                ('file.txt', 'file', 6, 536428800),
+                ('implicit_folder/.gitkeep', 'file', 4, zip_tuple_timestamp((1990, 1, 1, 0, 0, 0))),
+                ('file.txt', 'file', 6, zip_tuple_timestamp((1987, 1, 1, 0, 0, 0))),
                 })
 
             self.assertEqual(set(util.zip_listdir(zip_filename, 'folder')), {
-                ('.gitkeep', 'file', 3, 599587200)
+                ('.gitkeep', 'file', 3, zip_tuple_timestamp((1989, 1, 1, 0, 0, 0)))
                 })
 
             self.assertEqual(set(util.zip_listdir(zip_filename, 'folder/')), {
-                ('.gitkeep', 'file', 3, 599587200)
+                ('.gitkeep', 'file', 3, zip_tuple_timestamp((1989, 1, 1, 0, 0, 0)))
                 })
 
             self.assertEqual(set(util.zip_listdir(zip_filename, 'implicit_folder')), {
-                ('.gitkeep', 'file', 4, 631123200)
+                ('.gitkeep', 'file', 4, zip_tuple_timestamp((1990, 1, 1, 0, 0, 0)))
                 })
 
             self.assertEqual(set(util.zip_listdir(zip_filename, 'implicit_folder/')), {
-                ('.gitkeep', 'file', 4, 631123200)
+                ('.gitkeep', 'file', 4, zip_tuple_timestamp((1990, 1, 1, 0, 0, 0)))
                 })
 
             with self.assertRaises(util.ZipDirNotFoundError):
@@ -598,9 +598,9 @@ class TestUtils(unittest.TestCase):
             # take zipfile.ZipFile
             with zipfile.ZipFile(zip_filename, 'r') as zip:
                 self.assertEqual(set(util.zip_listdir(zip, '')), {
-                    ('folder', 'dir', None, 567964800),
+                    ('folder', 'dir', None, zip_tuple_timestamp((1988, 1, 1, 0, 0, 0))),
                     ('implicit_folder', 'dir', None, None),
-                    ('file.txt', 'file', 6, 536428800),
+                    ('file.txt', 'file', 6, zip_tuple_timestamp((1987, 1, 1, 0, 0, 0))),
                     })
         finally:
             try:


### PR DESCRIPTION
Prevent remaining failures due to comparison Zip date-time objects in local timezone with absolute UNIX epoch timestamps.

Really fix #20