### PR TITLE
Fix non-unique ids in exporter

### DIFF
--- a/webscrapbook/scrapbook/exporter.py
+++ b/webscrapbook/scrapbook/exporter.py
@@ -88,6 +88,7 @@ class Exporter():
 
         # generate a unique timestamp as prefix
         ts = datetime.now(timezone.utc)
+        ts = ts.replace(microsecond=(ts.microsecond // 1000)*1000)
         while ts in self.used_ts:
             ts += timedelta(milliseconds=1)
         self.used_ts.add(ts)


### PR DESCRIPTION
Timestamp precision is microseconds during check for uniqueness
but when converted to id, it is truncated to milliseconds,
so id clash could happen during export.

Explicitly reset microsecond part during generation of id.