### PR TITLE
Avoid timeout  in test_app_actions.TestLock.test_directory_existed

### DIFF
--- a/test/test_app_actions.py
+++ b/test/test_app_actions.py
@@ -2316,7 +2316,7 @@ class TestLock(unittest.TestCase):
                 'a': 'lock',
                 'f': 'json',
                 'name': 'test',
-                'chkt': 0,
+                'chkt': 0.1,
                 })
 
             mock_abort.assert_called_once_with(500, 'Unable to create lock "test".')


### PR DESCRIPTION
On Linux invoking lock action with zero timeout causes
namely timeout exception due to high precision clock.