### PR TITLE
Fix test atime and ctime instabilities

### DIFF
--- a/test/test_scrapbook_cache.py
+++ b/test/test_scrapbook_cache.py
@@ -2938,6 +2938,15 @@ class TestStaticSiteGenerator(TestCache):
 
         os.makedirs(self.test_tree)
 
+    def assertStatEqual(self, first, second, msg=None):
+        def accept(key):
+            return key.startswith('st_') and not key.startswith('st_atime')
+
+        def to_dict(x):
+            return dict(((k, getattr(x, k)) for k in dir(x) if accept(k)))
+
+        self.assertEqual(to_dict(first), to_dict(second), msg)
+
     def test_update01(self):
         """Create nonexisting files"""
         check_files = [
@@ -2980,7 +2989,7 @@ class TestStaticSiteGenerator(TestCache):
         for path in check_files:
             with self.subTest(path=path):
                 file = os.path.normpath(os.path.join(self.test_tree, path))
-                self.assertEqual(os.stat(file), orig_stats[file])
+                self.assertStatEqual(os.stat(file), orig_stats[file])
 
     def test_update02(self):
         """Overwrite existing different files"""


### PR DESCRIPTION
Some tests failed from time to time due to `st_atime` or `st_ctime` `stat` attributes. I do not see any reason to check them during of comparison of files since they depend on precise timings of file system operations.

Maybe there is a better way to fix the tests.

```
while python3 -m unittest -v test.test_scrapbook_cache.TestStaticSiteGenerator.test_update01 ; do : ; done

...

======================================================================
FAIL: test_update01 (test.test_scrapbook_cache.TestStaticSiteGenerator) (path='search.html')
Create nonexisting files
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/danny0838/PyWebScrapBook/test/test_scrapbook_cache.py", line 2983, in test_update01
    self.assertEqual(os.stat(file), orig_stats[file])
AssertionError: os.st[106 chars] st_atime=1608267118, st_mtime=1608267117, st_ctime=1608267117) != os.st[106 chars] st_atime=1608267117, st_mtime=1608267117, st_ctime=1608267117)

----------------------------------------------------------------------
```

```
FAIL: test_file (test.test_app_actions.TestMove)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/danny0838/PyWebScrapBook/test/test_app_actions.py", line 3825, in test_file
    is_move=True,
  File "/home/ubuntu/danny0838/PyWebScrapBook/test/test_app_actions.py", line 110, in assert_file_equal
    self.assertEqual(datas[0]['stat'], datas[i]['stat'])
AssertionError: os.st[103 chars] st_atime=1608270835, st_mtime=1608270835, st_ctime=1608270835) != os.st[103 chars] st_atime=1608270835, st_mtime=1608270835, st_ctime=1608270836)

----------------------------------------------------------------------
```