### PR TITLE
test_util: Fix timezone math

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -73,7 +73,10 @@ class TestUtils(unittest.TestCase):
         # create an ID from corresponding local time if datetime is another timezone
         self.assertEqual(
             util.datetime_to_id_legacy(datetime(2020, 1, 2, 3, 4, 5, 67000, tzinfo=timezone.utc)),
-            util.datetime_to_id_legacy(datetime(2020, 1, 2, 3, 4, 5, 67000) + datetime.now().astimezone().utcoffset())
+            util.datetime_to_id_legacy(
+                datetime(2020, 1, 2, 3, 4, 5, 67000)
+                + datetime(2020, 1, 2, 3, 4, 5, 67000).astimezone().utcoffset()
+            )
         )
 
         # create for now if datetime not provided


### PR DESCRIPTION
When adjusting local-time `datetime` objects by `.utcoffset()`, the offset value has to be taken from the SAME datetime. When another value is used (or `now()`) that has a different DST status than the current date, the result will be off by an hour.

### Without this fix:

```console
$ tox run -e py311
[...]
======================================================================
FAIL: test_datetime_to_id_legacy (tests.test_util.TestUtils.test_datetime_to_id_legacy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../tests/test_util.py", line 74, in test_datetime_to_id_legacy
    self.assertEqual(
AssertionError: '20200101220405' != '20200101230405'
- 20200101220405
?          ^
+ 20200101230405
?          ^

```

### With this fix:

(...passes...)
