### PR TITLE
Add salt to authorization cache

### DIFF
--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -489,6 +489,9 @@ class TestWebHost(Test):
                 'pbkdf2:sha1:1$z$ab55d4e716ba0d6cc1a7259f346c42280e09a1e3',
                 'pass1',
             )
+            self.assertEqual(1, len(wsbapp.host._get_permission_cache))
+            self.assertEqual(wsbapp.host.get_permission('user1', 'pass1'), '')
+            self.assertEqual(1, len(wsbapp.host._get_permission_cache))
 
             self.assertEqual(wsbapp.host.get_permission('user2', 'pass2'), 'view')
             mock_encrypt.assert_called_with(


### PR DESCRIPTION
Protect `get_permission` cache against obtaining passwords using rainbow tables by adding random salt.

It is a palliative measure. A proper solution would use an OAuth2-like flow with exchange of passwords (expensive to validate) to short-living tokens (that are getting expired before can be recovered from memory dumps with reasonable cost).

Consider it as just an idea to discuss. Feel free to decline it or to commit another implementation.