### PR TITLE
A few packaging/environment tweaks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,13 +40,12 @@ install_requires =
 packages = find:
 
 [options.extras_require]
-dev =
-    # build
+build =
     pyinstaller
     build
     twine
 
-    # lint
+lint =
     flake8 >= 4.0
     pep8-naming >= 0.13.2
     flake8-comprehensions >= 3.7
@@ -56,8 +55,13 @@ dev =
     flake8-isort >= 4.2
     isort >= 5.5
 
-    # test
+test =
     tox >= 4.0
+
+dev =
+    webscrapbook[build]
+    webscrapbook[lint]
+    webscrapbook[test]
 
 adhoc_ssl =
     cryptography

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ requires = virtualenv<20.27.0
 description = run unit tests
 extras =
     adhoc_ssl
-    dev
+    build
 commands =
     python -m unittest {posargs}
 


### PR DESCRIPTION
In two separate commits, this PR does the following:

1. Create three new extras for the package, `build`, `lint`, and `test`, which contain the subset of dev dependencies belonging to each. The `dev` extra is redefined as a meta-extra which contains the other three. This allows more granular management of dependency installation in various situations, which ensuring that the `pip install webscrapbook[dev]` experience remains unaffected.

2. Switch the `tox.ini` testenv definition from using the `dev` extra to just the `build` extra, since neither the `tox` package nor the linters are needed inside the individual test environments; they're only used by the parent environment.

(TBH I'm not sure even the `build` dependencies are necessary in the testenv environment, since webscrapbook is packaged into those environments by the parent `tox` as part of the initial testenv preflight stuff. By the time it's ready to run test, there's no more need for build tools anymore. IIUC.)

### The `virtualenv` version restriction

It'd really be great to also get the `requires = virtualenv<20.27.0` line out of the `tox.ini`, because it affects _every_ Python version used to run `tox`. If there's a newer `virtualenv` installed (which is almost always the case), `tox` it does an extra "provisioning" step where it creates a wrapper virtualenv just so it can forcibly downgrade the `virtualenv` version.

TBH I don't quite  understand why it's necessary. I **SEE** the note in the Tox documentation about it being necessary, but I haven't been able to figure out _how_ or _why_. Doing a `pip install tox` when running Python 3.7 in the parent environment will automatically pull in virtualenv version 20.26.6, because Pip knows newer versions aren't compatible with Python3.7. That information is expressed in the metadata.

And if my Fedora 42 system's Python 3.13 with virtualenv 20.29.1 is the parent environment, then running `tox -e py37` works just fine even with the `requires = virtualenv<20.27.0` line commented out in `tox.ini`. 
`¯\_(ツ)_/¯`